### PR TITLE
Police Boss menu for default police interior

### DIFF
--- a/client/cl_config.lua
+++ b/client/cl_config.lua
@@ -5,7 +5,7 @@ Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target in
 
 Config.BossMenus = {
     ['police'] = {
-        vector3(461.45, -986.2, 30.73),
+        vector3(447.26, -974.45, 30.69),
     },
     ['ambulance'] = {
         vector3(335.46, -594.52, 43.28),
@@ -26,7 +26,7 @@ Config.BossMenus = {
 
 Config.BossMenuZones = {
     ['police'] = {
-        { coords = vector3(461.45, -986.2, 30.73), length = 0.35, width = 0.45, heading = 351.0, minZ = 30.58, maxZ = 30.68 } ,
+        { coords = vector3(447.26, -974.45, 30.69), length = 1.5, width = 2.8, heading = 0, minZ = 29.64, maxZ = 30.64 } ,
     },
     ['ambulance'] = {
         { coords = vector3(335.46, -594.52, 43.28), length = 1.2, width = 0.6, heading = 341.0, minZ = 43.13, maxZ = 43.73 },


### PR DESCRIPTION
If your PR is to fix an issue mention that issue here
I think you guys have put the police boss menu to be usable in the gabz mrpd and not the default police interior so I changed the coords to be like this in the video below.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes (Be honest)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
- 
https://user-images.githubusercontent.com/80643454/188849307-f4770904-9bd5-4490-b5b9-0e6009bf321e.mp4
