### PR TITLE
misspelled amount gangs

### DIFF
--- a/client/cl_gang.lua
+++ b/client/cl_gang.lua
@@ -292,8 +292,8 @@ RegisterNetEvent('qb-gangmenu:client:SocietyDeposit', function(saldoattuale)
         }
     })
     if deposit then
-        if not deposit.amount then return end
-        TriggerServerEvent("qb-gangmenu:server:depositMoney", tonumber(deposit.amount))
+        if not deposit.Amount then return end
+        TriggerServerEvent("qb-gangmenu:server:depositMoney", tonumber(deposit.Amount))
     end
 end)
 
@@ -311,8 +311,8 @@ RegisterNetEvent('qb-gangmenu:client:SocietyWithdraw', function(saldoattuale)
         }
     })
     if withdraw then
-        if not withdraw.amount then return end
-        TriggerServerEvent("qb-gangmenu:server:withdrawMoney", tonumber(withdraw.amount))
+        if not withdraw.Amount then return end
+        TriggerServerEvent("qb-gangmenu:server:withdrawMoney", tonumber(withdraw.Amount))
     end
 end)
 


### PR DESCRIPTION
deposit.amount -> deposit.Amount
withdraw.amount -> withdraw.Amount

Describe Pull request
simple misspelling of the key amount

If your PR is to fix an issue mention that issue here

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
Does your code fit the style guidelines? yes
Does your PR fit the contribution guidelines? yes
