### PR TITLE
amount fix

### DIFF
--- a/client/cl_boss.lua
+++ b/client/cl_boss.lua
@@ -285,14 +285,14 @@ RegisterNetEvent('qb-bossmenu:client:SocetyDeposit', function(money)
             {
                 type = 'number',
                 isRequired = true,
-                name = Lang:t("body.amount"),
+                name = 'amount',
                 text = Lang:t("body.amount")
             }
         }
     })
     if deposit then
-        if not deposit.Amount then return end
-        TriggerServerEvent("qb-bossmenu:server:depositMoney", tonumber(deposit.Amount))
+        if not deposit.amount then return end
+        TriggerServerEvent("qb-bossmenu:server:depositMoney", tonumber(deposit.amount))
     end
 end)
 
@@ -304,14 +304,14 @@ RegisterNetEvent('qb-bossmenu:client:SocetyWithDraw', function(money)
             {
                 type = 'number',
                 isRequired = true,
-                name = Lang:t("body.amount"),
+                name = 'amount',
                 text = Lang:t("body.amount")
             }
         }
     })
     if withdraw then
-        if not withdraw.Amount then return end
-        TriggerServerEvent("qb-bossmenu:server:withdrawMoney", tonumber(withdraw.Amount))
+        if not withdraw.amount then return end
+        TriggerServerEvent("qb-bossmenu:server:withdrawMoney", tonumber(withdraw.amount))
     end
 end)
 

--- a/client/cl_gang.lua
+++ b/client/cl_gang.lua
@@ -292,8 +292,8 @@ RegisterNetEvent('qb-gangmenu:client:SocietyDeposit', function(saldoattuale)
         }
     })
     if deposit then
-        if not deposit.amount then return end
-        TriggerServerEvent("qb-gangmenu:server:depositMoney", tonumber(deposit.amount))
+        if not deposit.Amount then return end
+        TriggerServerEvent("qb-gangmenu:server:depositMoney", tonumber(deposit.Amount))
     end
 end)
 
@@ -311,8 +311,8 @@ RegisterNetEvent('qb-gangmenu:client:SocietyWithdraw', function(saldoattuale)
         }
     })
     if withdraw then
-        if not withdraw.amount then return end
-        TriggerServerEvent("qb-gangmenu:server:withdrawMoney", tonumber(withdraw.amount))
+        if not withdraw.Amount then return end
+        TriggerServerEvent("qb-gangmenu:server:withdrawMoney", tonumber(withdraw.Amount))
     end
 end)
 

--- a/client/cl_gang.lua
+++ b/client/cl_gang.lua
@@ -286,14 +286,14 @@ RegisterNetEvent('qb-gangmenu:client:SocietyDeposit', function(saldoattuale)
             {
                 type = 'number',
                 isRequired = true,
-                name = Lang:t("bodygang.amount"),
+                name = 'amount',
                 text = Lang:t("bodygang.amount")
             }
         }
     })
     if deposit then
-        if not deposit.Amount then return end
-        TriggerServerEvent("qb-gangmenu:server:depositMoney", tonumber(deposit.Amount))
+        if not deposit.amount then return end
+        TriggerServerEvent("qb-gangmenu:server:depositMoney", tonumber(deposit.amount))
     end
 end)
 
@@ -305,14 +305,14 @@ RegisterNetEvent('qb-gangmenu:client:SocietyWithdraw', function(saldoattuale)
             {
                 type = 'number',
                 isRequired = true,
-                name = Lang:t("bodygang.amount"),
+                name = 'amount',
                 text = Lang:t("bodygang.amount")
             }
         }
     })
     if withdraw then
-        if not withdraw.Amount then return end
-        TriggerServerEvent("qb-gangmenu:server:withdrawMoney", tonumber(withdraw.Amount))
+        if not withdraw.amount then return end
+        TriggerServerEvent("qb-gangmenu:server:withdrawMoney", tonumber(withdraw.amount))
     end
 end)
 


### PR DESCRIPTION
name = Lang:t("body.amount"),  ->  name = 'amount',
deposit.Amount -> deposit.amount

Describe Pull request
based on the #78
simple misspelling of the key amount back for amount from Amount
and Lang:t to 'amount'

If your PR is to fix an issue mention that issue here

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
Does your code fit the style guidelines? yes
Does your PR fit the contribution guidelines? yes