### PR TITLE
fix(client/config): set police bossmenu zone to usable size and position

### DIFF
--- a/client/cl_config.lua
+++ b/client/cl_config.lua
@@ -26,8 +26,7 @@ Config.BossMenus = {
 
 Config.BossMenuZones = {
     ['police'] = {
-        { coords = vector3(461.45, -986.2, 30.73), length = 0.35, width = 0.45, heading = 351.0, minZ = 30.58, maxZ = 30.68 } ,
-    },
+        { coords = vector3(447.23, -974.3, 31.47), length = 1.35, width = 1.45, heading = 351.0, minZ = 30.00, maxZ = 31.73 },    },
     ['ambulance'] = {
         { coords = vector3(335.46, -594.52, 43.28), length = 1.2, width = 0.6, heading = 341.0, minZ = 43.13, maxZ = 43.73 },
     },


### PR DESCRIPTION
**Describe Pull request**
The police bossmenu zone was tiny and unusable.

Zone now covers a desk and is targetable.
![image](https://user-images.githubusercontent.com/96954031/219717500-bb88334b-d822-4167-a039-3e0d91ec7213.png)

Not tested by me.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [no] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
