### PR TITLE
This PR fixes issue #59

### DIFF
--- a/client/cl_gang.lua
+++ b/client/cl_gang.lua
@@ -359,6 +359,7 @@ CreateThread(function()
                                     nearGangmenu = true
                                     if not shownGangMenu then
                                         exports['qb-core']:DrawText(Lang:t("drawtextgang.label"), 'left')
+                                        shownGangMenu = true
                                     end
 
                                     if IsControlJustReleased(0, 38) then


### PR DESCRIPTION
This PR fixes issue - #59 ,in which it was stated that the gang menu stayed on player's screen even though the player moved far away from the menu's position.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
