### PR TITLE
Update sv_boss.lua

### DIFF
--- a/server/sv_boss.lua
+++ b/server/sv_boss.lua
@@ -26,7 +26,7 @@ QBCore.Functions.CreateCallback('qb-bossmenu:server:GetEmployees', function(sour
 
 	local employees = {}
 
-	local players = MySQL.query.await('SELECT citizenid,job,charinfo FROM `players` WHERE JSON_EXTRACT(job, "$.name") = "'..jobname.. '"', {})
+	local players = MySQL.query.await('SELECT citizenid,job,charinfo FROM `players` WHERE JSON_EXTRACT(job, "$.name") = ?', {jobname})
 
 	if players[1] ~= nil then
 		for _, value in pairs(players) do

--- a/server/sv_boss.lua
+++ b/server/sv_boss.lua
@@ -26,7 +26,7 @@ QBCore.Functions.CreateCallback('qb-bossmenu:server:GetEmployees', function(sour
 
 	local employees = {}
 
-	local players = MySQL.query.await("SELECT * FROM `players` WHERE `job` LIKE '%" .. jobname .. "%'", {})
+	local players = MySQL.query.await('SELECT citizenid,job,charinfo FROM `players` WHERE JSON_EXTRACT(job, "$.name") = "'..jobname.. '"', {})
 
 	if players[1] ~= nil then
 		for _, value in pairs(players) do


### PR DESCRIPTION
**Describe Pull request**
When having multiple job jobs with the same type, the employee list fills with all users containing that type in the 'job' record.
E.g.: job 'mechanic' and type 'mechanic' get mixed up in this list causing other jobs to pop up in an employee list

This fixes it and searches for the job in the JSON, so it results only in the employees of that job.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
